### PR TITLE
Fixed Command Injection

### DIFF
--- a/scp.js
+++ b/scp.js
@@ -18,7 +18,7 @@ scp.send = function (options, cb) {
     options.file,
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.path,
   ];
-  execFile('scp', [command], function (err, stdout, stderr) {
+  execFile('scp', command, function (err, stdout, stderr) {
     if (cb) {
       cb(err, stdout, stderr);
     } else {

--- a/scp.js
+++ b/scp.js
@@ -2,7 +2,7 @@
  * node-scp
  * <cam@onswipe.com>
  */
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 
 var scp = module.exports = {};
 
@@ -41,7 +41,9 @@ scp.get = function (options, cb) {
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.file,
     options.path
   ];
-  exec(command.join(' '), function (err, stdout, stderr) {
+  var cmdFile = command[0];
+  command.shift();
+  execFile(cmdFile, [command], function (err, stdout, stderr) {
     if (cb) {
       cb(err, stdout, stderr);
     } else {

--- a/scp.js
+++ b/scp.js
@@ -39,7 +39,7 @@ scp.get = function (options, cb) {
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.file,
     options.path
   ];
-  execFile('scp', [command], function (err, stdout, stderr) {
+  execFile('scp', command, function (err, stdout, stderr) {
     if (cb) {
       cb(err, stdout, stderr);
     } else {

--- a/scp.js
+++ b/scp.js
@@ -11,7 +11,6 @@ var scp = module.exports = {};
  */
 scp.send = function (options, cb) {
   var command = [
-    'scp',
     '-r',
     '-P',
     (options.port == undefined ? '22' : options.port),
@@ -19,7 +18,7 @@ scp.send = function (options, cb) {
     options.file,
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.path,
   ];
-  exec(command.join(' '), function (err, stdout, stderr) {
+  execFile('scp', [command], function (err, stdout, stderr) {
     if (cb) {
       cb(err, stdout, stderr);
     } else {
@@ -33,7 +32,6 @@ scp.send = function (options, cb) {
  */
 scp.get = function (options, cb) {
   var command = [
-    'scp',
     '-r',
     '-P',
     (options.port == undefined ? '22' : options.port),
@@ -41,9 +39,7 @@ scp.get = function (options, cb) {
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.file,
     options.path
   ];
-  var cmdFile = command[0];
-  command.shift();
-  execFile(cmdFile, [command], function (err, stdout, stderr) {
+  execFile('scp', [command], function (err, stdout, stderr) {
     if (cb) {
       cb(err, stdout, stderr);
     } else {


### PR DESCRIPTION
### ⚙️ Description *

The vulnerability is caused due to the usage of `child_process`'s `exec()` function which is vulnerable to Command Injection. Replacing the `exec()` function with `execFile()` function will mitigate this vulnerability.

### 💻 Technical Description *

The occurrence of this vulnerability is caused due to the usage of the `exec()` function. So replacing the `exec()` function with `execFile()` is enough to fix the issue.

Here is how it works:

```javascript
execFile('scp', [command], function (err, stdout, stderr) {
  if (cb) {
    cb(err, stdout, stderr);
  } else {
    if (err) throw new Error(err);
  }
});
```

Here the utility used is `scp` so that is set as the binary file for the `execFile()` function. So the `scp` element from `command[]` array is taken out to just pass as an argument array to `execFile()`.

There was only one permalink on where the issue arose although there were 2 `exec()` functions being used in `send()` and `get()` function respectively. All of them have been fixed!

### 🐛 Proof of Concept (PoC) *

_**Place the file under the root directory of the project (`poc.js`)**_

```javascript
// poc.js
var scp = require('./scp.js');
 
var options = {
  file: 'dump.sql',
  user: 'username',
  host: 'myServer',
  port: '22; touch HACKED; #',
  path: '~'
}
 
scp.send(options, function (err) {
  if (err) console.log(err);
  else console.log('File transferred.');
});
```

### 🔥 Proof of Fix (PoF) *

    $ cd node-scp/
    $ npm install
    $ node poc.js

![node-scp-fix](https://user-images.githubusercontent.com/26198477/81430131-903b5080-917c-11ea-9405-ba24634d9691.png)

As you can see from the above screenshot, there is no file named `HACKED` created thus fixing the issue.

### 👍 User Acceptance Testing (UAT)

The replacement of the `exec()` function with `execFile()` is the only change implemented.
