### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/scp.js
+++ b/scp.js
@@ -2,7 +2,7 @@
  * node-scp
  * <cam@onswipe.com>
  */
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 
 var scp = module.exports = {};
 
@@ -11,15 +11,15 @@ var scp = module.exports = {};
  */
 scp.send = function (options, cb) {
   var command = [
-    'scp',
     '-r',
     '-P',
     (options.port == undefined ? '22' : options.port),
-    '-o "ControlMaster no"', //callback is not fired if ssh sessions are shared
+    '-o',
+    'ControlMaster no', //callback is not fired if ssh sessions are shared
     options.file,
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.path,
   ];
-  exec(command.join(' '), function (err, stdout, stderr) {
+  execFile('scp', command, function (err, stdout, stderr) {
     if (cb) {
       cb(err, stdout, stderr);
     } else {
@@ -33,15 +33,15 @@ scp.send = function (options, cb) {
  */
 scp.get = function (options, cb) {
   var command = [
-    'scp',
     '-r',
     '-P',
     (options.port == undefined ? '22' : options.port),
-    '-o "ControlMaster no"', //callback is not fired if ssh sessions are shared
+    '-o',
+    'ControlMaster no', //callback is not fired if ssh sessions are shared
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.file,
     options.path
   ];
-  exec(command.join(' '), function (err, stdout, stderr) {
+  execFile('scp', command, function (err, stdout, stderr) {
     if (cb) {
       cb(err, stdout, stderr);
     } else {

--- a/test/get.js
+++ b/test/get.js
@@ -1,7 +1,7 @@
 var scp = require('../');
 
 scp.get({
-  file: '~/test',
+  file: '~/what',
   host: 'core',
   path: './test/what'
 }, function () {


### PR DESCRIPTION
### ⚙️ Description 

I've remedied the command injection vulnerability by using a more secure method to run the `scp` command.

### 💻 Technical Description 

I've replaced the usage of `exec` in this module with `execFile`, which automatically escapes the command variables being passed to `scp`.

### 🐛 Proof of Concept (PoC) 

When running the following snippet in the node-scp directory, a file named `HACKED` should show up in your current working directory, proving the command injection vulnerability:
```js
const client = require("./scp");
client.get({ port: "; touch HACKED ;" })
```

### 🔥 Proof of Fix (PoF) 

When the above snippet is ran on my fork of the module, the execution fails with the error "`Bad port '; touch HACKED ;'`", which indicates the port variable has been escaped.

![image](https://user-images.githubusercontent.com/8684677/81420033-92d38100-914f-11ea-9089-52bb2299ebfb.png)


### 👍 User Acceptance Testing (UAT)

I've fixed the `get` test to request the correct file, as it requested a different file when being ran. Running the included tests after setting up a SSH location named `core` proves that the module is  working perfectly fine:

```bash
$ node test/send.js
[Arguments] { '0': null, '1': '', '2': '' }

$ node test/get.js
[Arguments] { '0': null, '1': '', '2': '' }
```

The file `what` showed up on my remote system and after deleting it locally and running test/get, it was properly re-downloaded.